### PR TITLE
fix: lowercase PLUGIN_NAME to match directory name on case-sensitive …

### DIFF
--- a/extensions/python/process_chain_end/_60_auto_dream.py
+++ b/extensions/python/process_chain_end/_60_auto_dream.py
@@ -16,7 +16,7 @@ class AutoDream(Extension):
         if self.agent.context.type == AgentContextType.BACKGROUND:
             return
 
-        config = plugins.get_plugin_config("AutoDream", self.agent) or {}
+        config = plugins.get_plugin_config("autodream", self.agent) or {}
         memory_config = plugins.get_plugin_config("_memory", self.agent) or {}
         if not memory_config.get("memory_memorize_enabled", True):
             return

--- a/helpers/auto_dream.py
+++ b/helpers/auto_dream.py
@@ -19,7 +19,7 @@ from initialize import initialize_agent
 from langchain_core.documents import Document
 
 
-PLUGIN_NAME = "AutoDream"
+PLUGIN_NAME = "autodream"
 MEMORY_PLUGIN_NAME = "_memory"
 
 AUTO_DREAM_DIR = "autodream"


### PR DESCRIPTION
…filesystems

On Linux (case-sensitive filesystem), PLUGIN_NAME = "AutoDream" caused find_plugin_dir() to look for /usr/plugins/AutoDream/ which does not exist. The directory is named "autodream" (lowercase), matching plugin.yaml name field.

This caused get_plugin_config() to return None on every chain end, making config.get("enabled") falsy and silently short-circuiting the extension before any dream cycle could run.

Fix: lowercase PLUGIN_NAME to "autodream" in both affected files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AutoDream plugin configuration loading to use correct identifier format, ensuring the plugin retrieves its settings properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->